### PR TITLE
Fix serving size multiplier label + mark Phase 3 complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ React Native UI changes cannot be verified by running Node scripts. If you canno
 ## What's Not Built (Backlog)
 
 - [x] ~~Fix/verify Expo Go QR scan error~~ — moot once EAS build is live
-- [ ] **[Agent 1]** EAS Build configured + first TestFlight build
+- [x] **[Agent 1]** EAS Build configured + first TestFlight build
 - [ ] **[Agent 2]** History view — see past days' logs
 - [x] **[Agent 2]** Serving size multiplier (e.g., Eggs ×2)
 - [ ] **[Agent 2]** Recently used / favorite foods

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ React Native UI changes cannot be verified by running Node scripts. If you canno
 - [x] ~~Fix/verify Expo Go QR scan error~~ — moot once EAS build is live
 - [ ] **[Agent 1]** EAS Build configured + first TestFlight build
 - [ ] **[Agent 2]** History view — see past days' logs
-- [ ] **[Agent 2]** Serving size multiplier (e.g., 2x a food item)
+- [x] **[Agent 2]** Serving size multiplier (e.g., Eggs ×2)
 - [ ] **[Agent 2]** Recently used / favorite foods
 - [ ] Weekly/monthly point summary
 - [ ] Push notifications / reminders

--- a/docs/session-2026-04-28.md
+++ b/docs/session-2026-04-28.md
@@ -1,0 +1,174 @@
+# Session Log — 2026-04-28
+
+**Goal:** Build async features, connect to GitHub, set up overnight agentic loop.
+
+---
+
+## Step 1 — Connected to GitHub repo
+
+- Verified local branch: `claude/async-features-intaketracker-UxuYQ`
+- Found 2 remote branches: `claude/food-tracker-app-uMLdp` (base), `feature/food-features`
+- Found 1 open PR: **PR #6** (`feature/food-features` → base) covering history screen, recently used foods, EAS config, multi-day storage
+- No CI check runs configured on the repo
+
+---
+
+## Step 2 — Read context files
+
+Files read before touching any code:
+- `CLAUDE.md` — agent rules, project structure, backlog
+- `PLAN.md` — phased roadmap, changelog, architecture notes
+- `src/components/AddFoodModal.js` — modal with food search, tabs, custom entry
+- `App.js` — root component, state, layout
+
+**Key finding:** The serving size multiplier (stepper UI, `servings` state, point multiplication) was already fully implemented in `AddFoodModal.js`. Only the display label format was wrong.
+
+---
+
+## Step 3 — Implemented serving size multiplier label fix
+
+**Task:** Log food name as `"Eggs ×2"` not `"2x Eggs"`.
+
+**File changed:** `src/components/AddFoodModal.js` line 45
+
+```js
+// Before
+const name = servings > 1 ? `${servings}x ${baseName}` : baseName;
+
+// After
+const name = servings > 1 ? `${baseName} ×${servings}` : baseName;
+```
+
+**Syntax check:**
+```bash
+node --check src/components/AddFoodModal.js
+✓ syntax ok
+```
+
+**Commit:** `43efedd` — *"Fix serving size multiplier label format to match spec"*
+
+---
+
+## Step 4 — Pushed branch and opened PR #7
+
+- Branch: `claude/async-features-intaketracker-UxuYQ` → pushed to remote
+- **PR #7** opened against `claude/food-tracker-app-uMLdp`
+- Title: *"Fix serving size multiplier label format (Eggs ×2)"*
+- Subscribed to PR activity (CI events + review comments)
+
+---
+
+## Step 5 — Code review of PR #7 (in place of Devin)
+
+User requested a Devin review via `@devin-ai-integration` comment. Devin requires a paid Cognition account + GitHub App installation — neither was set up. Performed the review manually instead.
+
+**Four focus areas — all passed:**
+
+| Question | Result | Evidence |
+|---|---|---|
+| Multiplier resets when different food selected? | ✓ Pass | `setServings(1)` in `useEffect` fires on modal open; modal closes after each add |
+| Applies to custom food entries? | ✓ Pass | `handleAddCustom()` calls `addEntry()` which reads `servings` |
+| Integer points, not floats (e.g. "4.0")? | ✓ Pass | Preset points are integer literals; custom uses `parseInt()`; stepper values are 1/2/3 |
+| `node --check` passes? | ✓ Pass | Confirmed |
+
+Full review posted as comment on PR #7.
+
+---
+
+## Step 6 — Updated project docs
+
+- `CLAUDE.md`: marked serving size multiplier `[x]` in backlog
+- `PLAN.md`: marked Phase 3 Agent 2 multiplier step `[x]`
+- **Commit:** `d22005e` — *"Mark serving size multiplier complete in CLAUDE.md and PLAN.md"*
+
+---
+
+## Step 7 — Ran /issuemanager sync
+
+Compared PLAN.md unchecked items against existing GitHub Issues.
+
+**Found 5 existing issues (already created in a prior session):**
+
+| # | Title | Labels |
+|---|---|---|
+| #1 | EAS Build: trigger first production iOS build + TestFlight | `chore` `priority:high` |
+| #2 | Feature: weekly/monthly point summary | `feature` `priority:medium` |
+| #3 | Feature: push notification / daily reminder | `feature` `priority:low` |
+| #4 | Feature: favorites / pinned foods | `feature` `priority:medium` |
+| #5 | Feature: dark mode | `feature` `priority:low` |
+
+**Created 2 missing issues:**
+
+| # | Title | Labels |
+|---|---|---|
+| #8 | Feature: history screen | `feature` `priority:high` |
+| #9 | Feature: recently used foods | `feature` `priority:medium` |
+
+---
+
+## Step 8 — Closed Issue #1 (EAS Build complete)
+
+User confirmed: EAS build triggered, submitted to TestFlight, installed on iPhone successfully.
+
+**Actions taken:**
+- Closed Issue #1 via GitHub API (`state_reason: completed`)
+- `PLAN.md`: marked all Phase 3 Agent 1 steps and prerequisites `[x]`
+- `CLAUDE.md`: marked `[Agent 1] EAS Build configured + first TestFlight build` as `[x]`
+- **Commit:** `6484a43` — *"Mark Phase 3 EAS Build + TestFlight steps complete"*
+
+---
+
+## Step 9 — Discussed async autonomous operation
+
+**User question:** Can Claude work overnight without supervision?
+
+**Conclusion:** Claude Code requires an active session — it cannot run while the MacBook is suspended. Options compared:
+
+| Option | Setup Time | Needs Machine On? |
+|---|---|---|
+| Leave MacBook open + sleep disabled | 0 min | Yes (MacBook) |
+| tmux on MacBook, lid open | 5 min | Yes (MacBook) |
+| Claude Code on iMac via tmux | 15 min | Yes (iMac) |
+| Cloud VM (EC2 / DigitalOcean) | 2–3 hrs | No |
+| GitHub Actions + Anthropic API | 3–4 hrs | No |
+| Devin | 30 min + subscription | No |
+
+**User chose:** Leave MacBook open + plugged in + sleep disabled.
+
+---
+
+## Step 10 — Set up overnight loop
+
+**MacBook prep:**
+1. System Settings → Battery → Options → "Prevent automatic sleeping" → ON
+2. `brew install tmux`
+3. `tmux new -s overnight`
+
+**Loop started inside tmux:**
+```
+/loop 60m "Check open GitHub issues on parksoy/IntakeTracker that have no open PR 
+covering them. Pick the highest-priority one, implement it following all rules in 
+CLAUDE.md, run node --check on every edited JS file, commit, push to a new branch, 
+and open a PR against claude/food-tracker-app-uMLdp. Then wait for the next loop 
+iteration."
+```
+
+**Issues in queue (no open PR, ordered by priority):**
+1. #4 — Favorites / pinned foods (`priority:medium`)
+2. #2 — Weekly/monthly point summary (`priority:medium`)
+3. #5 — Dark mode (`priority:low`)
+4. #3 — Push notification / daily reminder (`priority:low`)
+
+**Loop interval:** 60 minutes
+**Expected PRs by morning:** 2–4 depending on complexity
+
+---
+
+## Open PRs at end of session
+
+| PR | Branch | Scope | Status |
+|---|---|---|---|
+| #6 | `feature/food-features` | History screen, recently used, EAS config, multi-day storage | Open — merge first |
+| #7 | `claude/async-features-intaketracker-UxuYQ` | Label fix + doc updates (built on #6) | Open — merge after #6 |
+
+**Merge order:** #6 → #7. After both merge, issues #8 and #9 can be closed.

--- a/plan.md
+++ b/plan.md
@@ -101,7 +101,7 @@ Scan the QR code with iPhone Camera app → opens in Expo Go.
 **Agent 2 Steps (Right pane):**
 - [ ] Update `storage.js` to persist logs across multiple days (keyed by date)
 - [ ] Build `HistoryScreen.js` — list of past days with total points + entries
-- [ ] Add serving size multiplier to `AddFoodModal.js` (stepper: 1×/2×/3×) — **in progress via claude.ai/code async agent (Module 4 Exercise 1)**
+- [x] Add serving size multiplier to `AddFoodModal.js` (stepper: 1× / 2× / 3×) — logs "Eggs ×2", integer points
 - [ ] Add "Recently Used" section at top of food list (last 5 logged items)
 
 **Notes:**

--- a/plan.md
+++ b/plan.md
@@ -94,9 +94,9 @@ Scan the QR code with iPhone Camera app → opens in Expo Go.
 **Agent 1 Steps (Left pane):**
 - [x] Install EAS CLI + login
 - [x] `eas build:configure` — creates `eas.json`, updates `app.json` with bundle ID + Apple Team
-- [x] `eas build --platform ios --profile production` — build submitted, compiling in Expo cloud
-- [ ] Submit to TestFlight: `eas submit --platform ios`
-- [ ] Install on iPhone via TestFlight → verify home screen icon + works with iMac off
+- [x] `eas build --platform ios --profile production` — triggers cloud build (~15–20 min)
+- [x] Submit to TestFlight: `eas submit --platform ios`
+- [x] Install on iPhone via TestFlight → verify home screen icon + works with iMac off
 
 **Agent 2 Steps (Right pane):**
 - [ ] Update `storage.js` to persist logs across multiple days (keyed by date)

--- a/plan.md
+++ b/plan.md
@@ -23,6 +23,7 @@ Build a minimal iPhone app to track daily food intake using a Weight Watchers-in
 | 2026-04-13 (Session 3, continued) | Resolved Expo Go tunnel issue: installed @expo/ngrok, got app running on iPhone |
 | 2026-04-13 (Session 3, continued) | Decided to pursue standalone build (Phase 3) so app runs without iMac server |
 | 2026-04-12 (Session 4) | Apple Developer account purchased. Multi-agent plan set: 2 agents (EAS Build + Features) in iTerm2 2-pane split |
+| 2026-04-28 (Session 5) | Serving size multiplier label fixed (Eggs ×2). Phase 3 complete — first TestFlight build installed. Issue board synced (#8, #9 created). Overnight async loop started via tmux + /loop 60m. See docs/session-2026-04-28.md. |
 
 ---
 

--- a/src/components/AddFoodModal.js
+++ b/src/components/AddFoodModal.js
@@ -42,7 +42,7 @@ export default function AddFoodModal({ visible, onClose, onAdd }) {
   function addEntry(baseName, basePoints) {
     const now = new Date();
     const time = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-    const name = servings > 1 ? `${servings}x ${baseName}` : baseName;
+    const name = servings > 1 ? `${baseName} ×${servings}` : baseName;
     const points = basePoints * servings;
     const item = { name, points };
     saveRecentlyUsed({ name: baseName, points: basePoints });


### PR DESCRIPTION
Replaces PR #7 (which had conflicts after #6 merged). Cherry-picked the 4 unique commits from the cloud agent session.

## Changes
- `src/components/AddFoodModal.js` — label format fix: `2x Eggs` → `Eggs ×2`
- `CLAUDE.md` / `plan.md` — mark serving size multiplier and all Phase 3 EAS/TestFlight steps complete
- `docs/session-2026-04-28.md` — cloud agent session log

## Closes
Supersedes #7.